### PR TITLE
add /congress/members/<govtrack_id>

### DIFF
--- a/person/urls.py
+++ b/person/urls.py
@@ -9,6 +9,7 @@ urlpatterns = patterns('person.views',
 
     url(r'^(?:([A-Za-z]+)(?:/(\d{1,2}))?)?/?$', 'browsemembersbymap'), # Wikipedia has bad links using state names instead of abbrs, so we support it
 	url(r'^[^/]+/(\d+)', 'person_details', name='person_details'),
+    url(r'^(\d+)', 'person_details', name='person_details'),
 	
     url(r'^ajax/district_lookup$', 'district_lookup'),
 	url(r'^embed/mapframe(?:\.xpd)?$', 'districtmapembed', name='districtmapembed'),


### PR DESCRIPTION
In the congress-legislators repo, the legislators YAML includes a govtrack id. However, govtrack doesn't currently serve this URL even though it uniquely identifies the congressperson. It's unideal to have to try to reconstruct something like http://www.govtrack.us/congress/members/max_baucus/300005 rather than just http://www.govtrack.us/congress/members/300005 . What do you think?
