### PR TITLE
Address #1: CSS cleanup

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -307,8 +307,6 @@ sub {
 .notebox {
   background: #ffdddd;
   border: solid #fcf3d0 1px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
   border-radius: 5px;
   margin-top: 15px;
   padding: 20px;
@@ -414,8 +412,6 @@ sub {
   background: -ms-linear-gradient(top,  #abd380 0%,#7fa659 100%); /* IE10+ */
   background: linear-gradient(to bottom,  #abd380 0%,#7fa659 100%); /* W3C */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#abd380', endColorstr='#7fa659',GradientType=0 ); /* IE6-9 */
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
   border-radius: 5px;
   border: 1px solid;
   border-color: #e3f1d5 #8eb566 #6f914d #8eb566;
@@ -1331,21 +1327,13 @@ a.button.prefix, a.button.postfix {
 
 .prefix {
   left: 2px;
-  -moz-border-radius-topright:        0;
-  -webkit-border-top-right-radius:    0;
   border-top-right-radius:            0;
-  -moz-border-radius-bottomright:     0;
-  -webkit-border-bottom-right-radius: 0;
   border-bottom-right-radius:         0;
 }
 
 .postfix {
   right: 2px;
-  -moz-border-radius-topleft:         0;
-  -webkit-border-top-left-radius:     0;
   border-top-left-radius:             0;
-  -moz-border-radius-bottomleft:      0;
-  -webkit-border-bottom-left-radius:  0;
   border-bottom-left-radius:          0;
 }
 
@@ -1400,8 +1388,6 @@ a.button.prefix, a.button.postfix {
     padding: 5px 10px 2px 0;
     background:#fafafa;
     color: #555;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
 }
 #content .main ul > li {
@@ -1666,8 +1652,6 @@ a.button.prefix, a.button.postfix {
   	}
   #nav ul ul li:hover a {
       background: #05647c;
-      -moz-border-radius: 4px;
-      -webkit-border-radius: 4px;
       border-radius: 4px;
   	}
 
@@ -2724,8 +2708,6 @@ aside .download-links { padding: 31px 0 0 	}
         background: #cb4b16;
         color: #fff;
         padding: 0 6px;
-        -moz-border-radius: 2px;
-        -webkit-border-radius: 2px;
         border-radius: 2px;
         height: 20px;
         display: inline-block;
@@ -2734,8 +2716,6 @@ aside .download-links { padding: 31px 0 0 	}
     color: #cb4b16;
     background: #dae2df;
     padding: 0 6px;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
     border-radius: 2px;
     text-decoration: none;
     display: inline-block;
@@ -2993,9 +2973,7 @@ aside .download-links { padding: 31px 0 0 	}
             padding: 20px;
             border: 1px solid #eee;
             margin-bottom: 20px;
-            /*moz-border-radius: 3px;
-            webkit-border-radius: 3px;
-            border-radius: 3px;*/
+            /*border-radius: 3px;*/
         }
         .tracked_event:hover {
             background: #fffcf5;
@@ -3039,8 +3017,6 @@ aside .download-links { padding: 31px 0 0 	}
                     margin-left: .5em;
                     border: solid #ddd 1px;
                     border-radius: 3px;
-                    moz-border-radius: 3px;
-                    webkit-border-radius: 3px;
                 }
 
             .event_date {
@@ -3076,8 +3052,6 @@ aside .download-links { padding: 31px 0 0 	}
     margin-bottom: 10px;
     background: #fff;
     border: solid #dcd6c3 1px;
-    moz-border-radius: 5px;
-    webkit-border-radius: 5px;
     border-radius: 5px;
     overflow: hidden;
     font-size: .9em;
@@ -3159,8 +3133,6 @@ aside .download-links { padding: 31px 0 0 	}
         z-index: 5;
         width: 308px;
         /*background: #f8f7f7;
-        -moz-border-radius: 1px;
-        -webkit-border-radius: 1px;
         border-radius: 1px;
         border: solid #e7e4dc 1px;
         -webkit-box-shadow:
@@ -3203,8 +3175,6 @@ aside .download-links { padding: 31px 0 0 	}
                 margin-bottom: 10px;
                 background: #fff;
                 border: solid #dcd6c3 1px;
-                moz-border-radius: 5px;
-                webkit-border-radius: 5px;
                 border-radius: 5px;
                 overflow: hidden;
                 font-size: .9em;
@@ -3489,16 +3459,12 @@ a.button.prefix, a.button.postfix { padding-left: 0; padding-right: 0; text-alig
 
 span.prefix, span.postfix { background: #f2f2f2; border: 1px solid #cccccc; }
 
-.prefix { left: 2px; -moz-border-radius-topleft: 2px; -webkit-border-top-left-radius: 2px; border-top-left-radius: 2px; -moz-border-radius-bottomleft: 2px; -webkit-border-bottom-left-radius: 2px; border-bottom-left-radius: 2px; }
+.prefix { left: 2px; border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 
-.postfix { right: 2px; -moz-border-radius-topright: 2px; -webkit-border-top-right-radius: 2px; border-top-right-radius: 2px; -moz-border-radius-bottomright: 2px; -webkit-border-bottom-right-radius: 2px; border-bottom-right-radius: 2px; }
+.postfix { right: 2px; border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
 
 input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="email"], input[type="number"], input[type="search"], input[type="tel"], input[type="time"], input[type="url"], textarea {
   border: 1px solid #cccccc;
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
-  -ms-border-radius: 2px;
-  -o-border-radius: 2px;
   border-radius: 2px;
   border: 2px solid;
   border-color: #e6d39c ;
@@ -3547,7 +3513,7 @@ textarea::-webkit-input-placeholder {
 }
 
 /* Fieldsets
-fieldset { border: solid 1px #ddd; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; padding: 12px 12px 0; margin: 18px 0; }
+fieldset { border: solid 1px #ddd; border-radius: 3px; padding: 12px 12px 0; margin: 18px 0; }
 fieldset legend { font-weight: bold; background: white; padding: 0 3px; margin: 0 0 0 -3px; }*/
 
 /* Errors */
@@ -3555,7 +3521,7 @@ fieldset legend { font-weight: bold; background: white; padding: 0 3px; margin: 
 
 .error label, label.error { color: #cb1f16; }
 
-.error small, small.error { display: block; padding: 6px 4px; margin-top: -13px; margin-bottom: 12px; background: #cb1f16; color: #fff; font-size: 12px; font-size: 1.2rem; font-weight: bold; -moz-border-radius-bottomleft: 2px; -webkit-border-bottom-left-radius: 2px; border-bottom-left-radius: 2px; -moz-border-radius-bottomright: 2px; -webkit-border-bottom-right-radius: 2px; border-bottom-right-radius: 2px; }
+.error small, small.error { display: block; padding: 6px 4px; margin-top: -13px; margin-bottom: 12px; background: #cb1f16; color: #fff; font-size: 12px; font-size: 1.2rem; font-weight: bold; border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; }
 
 @media only screen and (max-width: 767px) { input[type="text"].one, .row input[type="text"].one, input[type="password"].one, .row input[type="password"].one, input[type="date"].one, .row input[type="date"].one, input[type="datetime"].one, .row input[type="datetime"].one, input[type="email"].one, .row input[type="email"].one, input[type="number"].one, .row input[type="number"].one, input[type="search"].one, .row input[type="search"].one, input[type="tel"].one, .row input[type="tel"].one, input[type="time"].one, .row input[type="time"].one, input[type="url"].one, .row input[type="url"].one, textarea.one, .row textarea.one { width: 100% !important; }
   input[type="text"].two, .row input[type="text"].two, input[type="password"].two, .row input[type="password"].two, input[type="date"].two, .row input[type="date"].two, input[type="datetime"].two, .row input[type="datetime"].two, input[type="email"].two, .row input[type="email"].two, input[type="number"].two, .row input[type="number"].two, input[type="search"].two, .row input[type="search"].two, input[type="tel"].two, .row input[type="tel"].two, input[type="time"].two, .row input[type="time"].two, input[type="url"].two, .row input[type="url"].two, textarea.two, .row textarea.two { width: 100% !important; }
@@ -3572,9 +3538,9 @@ fieldset legend { font-weight: bold; background: white; padding: 0 3px; margin: 
 /* Custom Forms ---------------------- */
 form.custom { /* Custom input, disabled */ }
 form.custom span.custom { display: inline-block; width: 16px; height: 16px; position: relative; top: 2px; border: solid 1px #ccc; background: #fff; }
-form.custom span.custom.radio { -webkit-border-radius: 100px; -moz-border-radius: 100px; -ms-border-radius: 100px; -o-border-radius: 100px; border-radius: 100px; }
+form.custom span.custom.radio { border-radius: 100px; }
 form.custom span.custom.checkbox:before { content: ""; display: block; line-height: 0.8; height: 14px; width: 14px; text-align: center; position: absolute; top: 0; left: 0; font-size: 14px; color: #fff; }
-form.custom span.custom.radio.checked:before { content: ""; display: block; width: 8px; height: 8px; -webkit-border-radius: 100px; -moz-border-radius: 100px; -ms-border-radius: 100px; -o-border-radius: 100px; border-radius: 100px; background: #222; position: relative; top: 3px; left: 3px; }
+form.custom span.custom.radio.checked:before { content: ""; display: block; width: 8px; height: 8px; border-radius: 100px; background: #222; position: relative; top: 3px; left: 3px; }
 form.custom span.custom.checkbox.checked:before { content: "\00d7"; color: #222; }
 form.custom div.custom.dropdown { display: block; position: relative; width: auto; height: 28px; margin-bottom: 9px; margin-top: 2px; }
 form.custom div.custom.dropdown a.current { display: block; width: auto; line-height: 26px; min-height: 28px; padding: 0 38px 0 6px; border: solid 1px #ddd; color: #141414; background-color: #fff; white-space: nowrap; }
@@ -3754,8 +3720,6 @@ select, input.text {
     font: 12px/16px CallunaSans, sans-serif;
     color: #444;
     border: solid #e6d39c 2px;
-    -moz-border-radius: 3px;
-    -webkit-border-radius: 3px;
     border-radius: 3px;
     -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box;
     }
@@ -3859,8 +3823,6 @@ select, input.text {
     #content div.advanced-search form {
         /*width: 896px;
         background: #f8f7f7;
-        -moz-border-radius: 1px;
-        -webkit-border-radius: 1px;
         border-radius: 1px;
         border: solid #e7e4dc 1px;
         -webkit-box-shadow:
@@ -3934,8 +3896,6 @@ select, input.text {
             padding: 2px 4px;
             margin: .25em 20px 0;
             border: solid #ddd 1px;
-            -moz-border-radius: 3px;
-            -webkit-border-radius: 3px;
             border-radius: 3px;
         }
         #search-results .results-group .more:hover {
@@ -3982,8 +3942,6 @@ ul.tabs a {
     letter-spacing: .15em;
     text-transform: uppercase;
     outline:0;
-    -webkit-border-radius: 4px 4px 0 0;
-    -moz-border-radius: 4px 4px 0 0;
     border-radius: 4px 4px 0 0;
 }
 	@media only screen and (max-width: 480px) {
@@ -4083,8 +4041,6 @@ ul.left-tabs a {
     text-decoration: none;
     font-family: 'PTSerifRegular', serif;
     outline:0;
-    -webkit-border-radius: 4px 4px 0 0;
-    -moz-border-radius: 4px 4px 0 0;
     border-radius: 4px 4px 0 0;
 }
 
@@ -4258,8 +4214,6 @@ ul.bullets li, .postcontent ul li, ol.bullets li, .postcontent ol li {
         margin: 0 10px;
     }
         #sitenews > div:first-of-type a {
-          -moz-border-radius: 12px;
-          -webkit-border-radius: 12px;
           border-radius: 12px;
           margin: -5px auto 0;
           text-align: center;

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -3638,7 +3638,7 @@ select, input.text {
     color: #444;
     border: solid #e6d39c 2px;
     border-radius: 3px;
-    -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box;
+    background-clip: padding-box;
     }
 .advanced-search select {
     width: 120px;

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -151,8 +151,8 @@ a {
     color: #cb4b16;
     text-decoration: none;
 	}
-a:hover { 
-	color: #664030; 
+a:hover {
+	color: #664030;
 	border-bottom: dotted #dfab96 1px;
 	}
 input, textarea, select {
@@ -169,8 +169,8 @@ h1, h2, h3, h4, h5 {
 	line-height: 130%;
 	color: #666;
 	}
-h1 { 
-    font-style: normal; 
+h1 {
+    font-style: normal;
     font-weight: 400;
     line-height: 1.5em;
     margin-bottom: 0.625em;
@@ -179,18 +179,18 @@ h1 {
     text-transform: none;
 }
 h2 {
-    font-size: 1.5em; 
+    font-size: 1.5em;
     line-height: 1.5em;
-    margin-bottom: 0.5em; 
+    margin-bottom: 0.5em;
 }
 h3 {
-	font-size: 1.3em; 
+	font-size: 1.3em;
 	text-transform: uppercase;
 }
 h4 {
 	font-size: 1.2em;
 }
-h5 { 
+h5 {
 	font-family: OpenSansRegular;
 	font-size: 1em;
 	text-transform: uppercase;
@@ -199,7 +199,7 @@ h5 {
 h2 span, h3 span, h4 span, span span, a em {
     font-family: PTSerifItalic;
     font-weight: normal;
-    font-style: normal;    
+    font-style: normal;
     text-transform: none;
 	}
 p+h2,
@@ -276,8 +276,8 @@ sub {
 .lt-ie9 img, object, embed {
   max-width: none;
 }
-.last { 
-	float: right !important; 
+.last {
+	float: right !important;
 	margin-right: 0 !important;
 	}
 .pv-speakup {
@@ -328,7 +328,7 @@ sub {
   font-style: italic;
     }
     .note strong {
-      
+
     }
     .note em {
       font-style: normal
@@ -405,7 +405,7 @@ sub {
 .button {
   display: block;
   width: auto;
-  background-size:1px 80px; 
+  background-size:1px 80px;
   background: #94bc6c; /* Old browsers */
   background: -moz-linear-gradient(top,  #abd380 0%, #7fa659 100%); /* FF3.6+ */
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#abd380), color-stop(100%,#7fa659)); /* Chrome,Safari4+ */
@@ -476,9 +476,9 @@ sub {
 @font-face {
   font-family: 'govtrack_icons_1';
   src: url("../fonts/govtrack_icons_1.eot");
-  src: url("../fonts/govtrack_icons_1.eot?#iefix") format('embedded-opentype'), 
-       url("../fonts/govtrack_icons_1.woff") format('woff'), 
-       url("../fonts/govtrack_icons_1.ttf") format('truetype'), 
+  src: url("../fonts/govtrack_icons_1.eot?#iefix") format('embedded-opentype'),
+       url("../fonts/govtrack_icons_1.woff") format('woff'),
+       url("../fonts/govtrack_icons_1.ttf") format('truetype'),
        url("../fonts/govtrack_icons_1.svg#govtrack_icons_1") format('svg');
   font-weight: normal;
   font-style: normal;
@@ -498,10 +498,10 @@ sub {
 /* fix buttons height */
   line-height: 1em;
 /* you can be more comfortable with increased icons size */
-  font-size: 120%; 
+  font-size: 120%;
 }
 [class^="icon-"]:hover:before,
-[class*=" icon-"]:hover:before { 
+[class*=" icon-"]:hover:before {
   opacity: 1;
   -webkit-transition: all 0.15s linear; -moz-transition: all 0.15s linear; -o-transition: all 0.15s linear; transition: all 0.15s linear;
 }
@@ -883,7 +883,7 @@ img {
 
 /* Mobile Grid and Overrides ---------------------- */
 @media only screen and (max-width: 767px) {
-  
+
   body {
     -webkit-text-size-adjust: none;
     -ms-text-size-adjust: none;
@@ -901,7 +901,7 @@ img {
   #breadcrumbs .row {
 	  padding: 0 4px 0 4px;
   }
- 
+
   .row {
     width: auto;
     min-width: 0;
@@ -909,18 +909,18 @@ img {
     margin-right: 0;
   }
 
-  
+
   .column, .columns {
     width: auto !important;
     float: none;
   }
 
-  
+
   .column:last-child, .columns:last-child {
     float: none;
   }
 
-  
+
   [class*="column"] + [class*="column"]:last-child {
     float: none;
   }
@@ -929,119 +929,119 @@ img {
     float: none !important;
   }
 
-  
+
   .column:before, .columns:before, .column:after, .columns:after {
     content: "";
     display: table;
   }
 
-  
+
   .column:after, .columns:after {
     clear: both;
   }
 
-  
+
   .offset-by-one, .offset-by-two, .offset-by-three, .offset-by-four, .offset-by-five, .offset-by-six, .offset-by-seven, .offset-by-eight, .offset-by-nine, .offset-by-ten {
     margin-left: 0 !important;
   }
 
-  
+
   .push-two, .push-three, .push-four, .push-five, .push-six, .push-seven, .push-eight, .push-nine, .push-ten {
     left: auto;
   }
 
-  
+
   .pull-two, .pull-three, .pull-four, .pull-five, .pull-six, .pull-seven, .pull-eight, .pull-nine, .pull-ten {
     right: auto;
   }
 
   /* Mobile 4-column Grid */
-  
+
   .row .mobile-one {
     width: 25% !important;
     float: left;
     padding: 0 10px;
   }
-  
+
   .row .mobile-one:last-child {
     float: right;
   }
-  
+
   .row.collapse .mobile-one {
     padding: 0;
   }
 
-  
+
   .row .mobile-two {
     width: 50% !important;
     float: left;
     padding: 0 10px;
   }
-  
+
   .row .mobile-two:last-child {
     float: right;
   }
-  
+
   .row.collapse .mobile-two {
     padding: 0;
   }
 
-  
+
   .row .mobile-three {
     width: 75% !important;
     float: left;
     padding: 0 10px;
   }
-  
+
   .row .mobile-three:last-child {
     float: right;
   }
-  
+
   .row.collapse .mobile-three {
     padding: 0;
   }
 
-  
+
   .row .mobile-four {
     width: 100% !important;
     float: left;
     padding: 0 10px;
   }
-  
+
   .row .mobile-four:last-child {
     float: right;
   }
-  
+
   .row.collapse .mobile-four {
     padding: 0;
   }
 
-  
+
   .push-one-mobile {
     left: 25%;
   }
 
-  
+
   .pull-one-mobile {
     right: 25%;
   }
 
-  
+
   .push-two-mobile {
     left: 50%;
   }
 
-  
+
   .pull-two-mobile {
     right: 50%;
   }
 
-  
+
   .push-three-mobile {
     left: 75%;
   }
 
-  
+
   .pull-three-mobile {
     right: 75%;
   }
@@ -1120,12 +1120,12 @@ that IE7/8 do not support :nth-child.
 /*  .block-grid.five-up>li:nth-child(5n+1) {clear: left;} */
 /* Mobile Block Grids */
 @media only screen and (max-width: 767px) {
-  
+
   .block-grid.mobile {
     margin-left: 0;
   }
 
-  
+
   .block-grid.mobile > li {
     float: none;
     width: 100%;
@@ -1173,7 +1173,7 @@ that IE7/8 do not support :nth-child.
 
 /* Very large display targeting */
 @media only screen and (min-width: 1441px) {
-  
+
   .hide-for-small,
   .hide-for-medium,
   .hide-for-large,
@@ -1181,7 +1181,7 @@ that IE7/8 do not support :nth-child.
     display: block !important;
   }
 
-  
+
   .show-for-small,
   .show-for-medium,
   .show-for-large,
@@ -1191,7 +1191,7 @@ that IE7/8 do not support :nth-child.
 }
 /* Medium display targeting */
 @media only screen and (max-width: 1279px) and (min-width: 768px) {
-  
+
   .hide-for-small,
   .show-for-medium,
   .hide-for-large,
@@ -1199,7 +1199,7 @@ that IE7/8 do not support :nth-child.
     display: block !important;
   }
 
-  
+
   .show-for-small,
   .hide-for-medium,
   .show-for-large,
@@ -1209,7 +1209,7 @@ that IE7/8 do not support :nth-child.
 }
 /* Small display targeting */
 @media only screen and (max-width: 767px) {
-  
+
   .show-for-small,
   .hide-for-medium,
   .hide-for-large,
@@ -1217,7 +1217,7 @@ that IE7/8 do not support :nth-child.
     display: block !important;
   }
 
-  
+
   .hide-for-small,
   .show-for-medium,
   .show-for-large,
@@ -1239,26 +1239,26 @@ that IE7/8 do not support :nth-child.
 }
 
 @media screen and (orientation: landscape) {
-  
+
   .show-for-landscape,
   .hide-for-portrait {
     display: block !important;
   }
 
-  
+
   .hide-for-landscape,
   .show-for-portrait {
     display: none !important;
   }
 }
 @media screen and (orientation: portrait) {
-  
+
   .show-for-portrait,
   .hide-for-landscape {
     display: block !important;
   }
 
-  
+
   .hide-for-portrait,
   .show-for-landscape {
     display: none !important;
@@ -1295,7 +1295,7 @@ table.hide-for-medium {
 }
 
 @media only screen and (max-width: 1279px) and (min-width: 768px) {
-  
+
   .touch table.hide-for-xlarge,
   .touch table.hide-for-large,
   .touch table.hide-for-small,
@@ -1304,7 +1304,7 @@ table.hide-for-medium {
   }
 }
 @media only screen and (max-width: 767px) {
-  
+
   table.hide-for-xlarge,
   table.hide-for-large,
   table.hide-for-medium,
@@ -1366,11 +1366,11 @@ a.button.prefix, a.button.postfix {
 .section {
     padding-bottom: 26px;
 	}
-.ads.square { 
+.ads.square {
 	width: 300px;
 	float: right;
 	}
-.ads.footer.leaderboard { 
+.ads.footer.leaderboard {
 	margin: 20px 0 20px 0;
 	text-align: center;
 	}
@@ -1434,7 +1434,7 @@ a.button.prefix, a.button.postfix {
 #content .main li ol,
 #content .main li ul {margin-top:6px;}
 #content .main ul ul li:last-child {margin-bottom:0;}
-	
+
 
 
 /* Header styles ====================================== */
@@ -1599,8 +1599,8 @@ a.button.prefix, a.button.postfix {
       text-align: center;
       display: block;
   	}
-  #nav li a:hover { 
-  	color: #664030; 
+  #nav li a:hover {
+  	color: #664030;
   	border-bottom: 0;
   	}
   #nav .dropnav:hover>a {
@@ -1623,8 +1623,8 @@ a.button.prefix, a.button.postfix {
       text-decoration: none;
       background: none;
   	}
-  #nav .dropnav a:hover { 
-  	color: #fff; 
+  #nav .dropnav a:hover {
+  	color: #fff;
   	}
   #nav li:hover { position: relative 	}
       #nav li:hover ul { display: block 	}
@@ -1670,7 +1670,7 @@ a.button.prefix, a.button.postfix {
       -webkit-border-radius: 4px;
       border-radius: 4px;
   	}
-	
+
 #mobile-nav { display: none; } /* Hide the mobile navigation */
 
 @media only screen and (max-width: 583px) { /* Strip down the header bar styling on smaller screens */
@@ -1699,7 +1699,7 @@ a.button.prefix, a.button.postfix {
     height: 320px;
     background: url(../images/bg-intro-box.jpg) 50% 0 no-repeat;
 	}
-    
+
     #intro-box h1 {
         font: normal 4.75em/1em PTSerifRegular;
         color: #fff;
@@ -1747,7 +1747,7 @@ a.button.prefix, a.button.postfix {
           text-align: right;
         }
 
-	
+
 #info-box {
     background: url(../images/bg-info-box-top.gif) repeat-x;
     font: 16px/22px Georgia, 'Times New Roman', Times, serif;
@@ -1810,7 +1810,7 @@ a.button.prefix, a.button.postfix {
     	#categories a:hover {
     		border-bottom: 0;
     		}
-    	
+
     	#categories #link-members a {
     		background: url(../images/img-congress-members.png) center 5px no-repeat;
     		}
@@ -1825,8 +1825,8 @@ a.button.prefix, a.button.postfix {
     		}
 
         .homepage #info-box .state {
-            margin: 1.5em 2em .3em 0; 
-            text-align: center; 
+            margin: 1.5em 2em .3em 0;
+            text-align: center;
         }
             .homepage #info-box .state span{
                 color: #444;
@@ -1838,8 +1838,8 @@ a.button.prefix, a.button.postfix {
                 font-family: 'PTSerifBold';
                 text-transform: uppercase;
             }
-        
-.entries-box { 
+
+.entries-box {
     background: url(../images/bg-entries-box-brown.jpg);
 }
     .entries-box .entries-holder {
@@ -2032,7 +2032,7 @@ a.button.prefix, a.button.postfix {
 
 /* Home Header break 2 ---------------------------- */
 @media only screen and (max-width: 770px) {
-   
+
   #intro-box h1 {
     margin-top: 38px;
     font-size: 3em;
@@ -2047,14 +2047,14 @@ a.button.prefix, a.button.postfix {
 /* Home Header break 3 ---------------------------- */
 @media only screen and (max-width: 582px) {
   #header { height: auto; }
-    #logo { 
+    #logo {
       margin: 10px 0;
       float: none;
       width: auto;
     }
     #nav { display: none; }
     #mobile-nav { display: block; }
-  
+
   #intro-box h1 {
     margin-top: .5em;
     margin-bottom: .5em;
@@ -2094,7 +2094,7 @@ a.button.prefix, a.button.postfix {
   }
 }
 
-/* Sub Page styles 
+/* Sub Page styles
    =========================================== */
 #breadcrumbs {
     background: url(../images/bg-breadcrumbs.jpg) no-repeat 50% 1px;
@@ -2315,15 +2315,15 @@ a.button.prefix, a.button.postfix {
   #search-members.section.row { margin-top: 0; padding: 0; }
 
   #search-again { margin-top: -15px; }
-    
+
     /* Category page icons */
   .heading-box #cat-icon {
     min-height: 146px;
   }
 	body.bills .heading-box #cat-icon {
 		min-height: 100px;
-	  }  
-    .search .heading-box #cat-icon { 
+	  }
+    .search .heading-box #cat-icon {
     	background: url(../images/cat-search.png) right center no-repeat;
 		}
 	.votes .heading-box #cat-icon,
@@ -2343,11 +2343,11 @@ a.button.prefix, a.button.postfix {
     .search.committees .heading-box #cat-icon {
     	background: url(../images/img-committees.png) right center no-repeat;
     	}
-        
+
     	.heading-box h1 {
             margin-bottom: .25em;
         }
-    	.heading-box h2 { 
+    	.heading-box h2 {
         	text-transform: uppercase;
         	}
 
@@ -2355,11 +2355,11 @@ a.button.prefix, a.button.postfix {
         	font-size: 95%;
         	line-height: normal;
         	}
-        	
+
         	.heading-box li {
         		margin-bottom: .5em;
         		}
-        	
+
 
 /* Member details styles
    ================================================== */
@@ -2564,7 +2564,7 @@ aside .download-links { padding: 31px 0 0 	}
 		font-size: 12px;
 		line-height: 15px;
 		margin: 0 0 .2em 0;
-	}    
+	}
     .metadata-table table {
         width: 100%;
         margin: 0 0 14px;
@@ -2586,7 +2586,7 @@ aside .download-links { padding: 31px 0 0 	}
         .metadata-table table .odd.done td { background: #e4e9e8 url('../images/ico-checked.gif') 8px center no-repeat; 	}
         .metadata-table table .odd.pending td { background: #e4e9e8 url('../images/ico-unchecked.gif') 8px center no-repeat; 	}
         .metadata-table tr.highlight td { font-weight: bold; }
-        
+
     .metadata-table .download-links {
         padding: 10px 0 0 107px;
         margin: 0 0 -15px;
@@ -2882,8 +2882,8 @@ aside .download-links { padding: 31px 0 0 	}
             text-transform: none;
             font-size: 1.25em;
         }
-    
-    
+
+
 #list_view {
     clear: both;
     margin-top: 20px;
@@ -2935,7 +2935,7 @@ aside .download-links { padding: 31px 0 0 	}
         border-bottom: solid #dfdbcf 1px;
     }
     #edit_list .control select {
-        float: right; 
+        float: right;
     }
     #edit_list h4,
     #edit_list label,
@@ -2989,7 +2989,7 @@ aside .download-links { padding: 31px 0 0 	}
 /*  Event styles for global use
     ========================================================= */
         .tracked_event {
-            clear: both; 
+            clear: both;
             padding: 20px;
             border: 1px solid #eee;
             margin-bottom: 20px;
@@ -3095,7 +3095,7 @@ aside .download-links { padding: 31px 0 0 	}
         width: 340px;
     }
 
-    #list_trackers li a,
+    #list_trackers li > a,
     #basic_trackers li span   {
         display: inline-block;
         float: right;
@@ -3106,7 +3106,7 @@ aside .download-links { padding: 31px 0 0 	}
         background: url(../images/icons.png) -12px 0 no-repeat;
         color: #666;
     }
-        #list_trackers li a:hover,
+        #list_trackers li > a:hover,
         #basic_trackers li a:hover span {
             background-position: -12px -12px;
             border-bottom: 0;
@@ -3115,7 +3115,7 @@ aside .download-links { padding: 31px 0 0 	}
     #basic_trackers li a:hover span { background-position: -24px -12px; }
 
 
-/*  Tracker widget styles 
+/*  Tracker widget styles
     =========================================================== */
     .track-btn, .push-btn {
         height: 39px;
@@ -3142,7 +3142,7 @@ aside .download-links { padding: 31px 0 0 	}
             background-position: 0 -43px;
             border-bottom: 0;
             }
-        .track-btn:active, .push-btn:active { 
+        .track-btn:active, .push-btn:active {
             background-position: 0 -86px;
         }
         .small-btn {
@@ -3289,11 +3289,11 @@ aside .download-links { padding: 31px 0 0 	}
             background: url(../images/tracker_widget_btm.png) center bottom no-repeat;
         }
 
-/* Create a Tracker Wizard styles 
+/* Create a Tracker Wizard styles
    ============================================================== */
 #tracker_wizard {
   }
-  
+
   #tracker_wizard .panel {
   }
 
@@ -3307,7 +3307,7 @@ aside .download-links { padding: 31px 0 0 	}
     border-bottom: #e7e4dc solid 1px;
     margin-bottom: 1em;
   }
-  
+
   #tracker_wizard .has_marker span {
     display: block;
     position: absolute;
@@ -3352,7 +3352,7 @@ aside .download-links { padding: 31px 0 0 	}
   }
   #tracker_search.small label {
     width: auto;
-    line-height: 30px; 
+    line-height: 30px;
   }
 
   #tracker_search #search_entry {
@@ -3394,7 +3394,7 @@ aside .download-links { padding: 31px 0 0 	}
 }
 
 
-/*  Footer Styles 
+/*  Footer Styles
     ======================================================== */
 #footer {
 	clear: both;
@@ -3428,7 +3428,7 @@ aside .download-links { padding: 31px 0 0 	}
             border-bottom: 1px solid #405255;
         	}
         #footer nav a {
-        	display: block 
+        	display: block
         	}
         #footer nav a:hover {
         	}
@@ -3459,11 +3459,11 @@ aside .download-links { padding: 31px 0 0 	}
 	}
 #footer .social a { display: block 	}
 #footer .social a:hover { text-decoration: none 	}
-#footer section { 
+#footer section {
     margin-bottom: 25px;
     overflow: hidden;
 }
-#footer p { 
+#footer p {
 	margin: 0 0 12px;
 /*	font-size: 12px;*/
 	line-height: 18px;
@@ -3493,39 +3493,39 @@ span.prefix, span.postfix { background: #f2f2f2; border: 1px solid #cccccc; }
 
 .postfix { right: 2px; -moz-border-radius-topright: 2px; -webkit-border-top-right-radius: 2px; border-top-right-radius: 2px; -moz-border-radius-bottomright: 2px; -webkit-border-bottom-right-radius: 2px; border-bottom-right-radius: 2px; }
 
-input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="email"], input[type="number"], input[type="search"], input[type="tel"], input[type="time"], input[type="url"], textarea { 
-  border: 1px solid #cccccc; 
-  -webkit-border-radius: 2px; 
-  -moz-border-radius: 2px; 
-  -ms-border-radius: 2px; 
-  -o-border-radius: 2px; 
-  border-radius: 2px; 
+input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="email"], input[type="number"], input[type="search"], input[type="tel"], input[type="time"], input[type="url"], textarea {
+  border: 1px solid #cccccc;
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  -ms-border-radius: 2px;
+  -o-border-radius: 2px;
+  border-radius: 2px;
   border: 2px solid;
   border-color: #e6d39c ;
   outline: 0;
   background: #ffffff url('../images/input_field.png') left top repeat-x;
-  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); 
-  -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); 
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); 
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   color: #555;
-  display: block; 
-  font-size: .85em; 
-  margin: 0 0 12px 0; 
-  padding: 6px; 
-  height: 32px; 
-  width: 100%; 
+  display: block;
+  font-size: .85em;
+  margin: 0 0 12px 0;
+  padding: 6px;
+  height: 32px;
+  width: 100%;
 }
-input[type="text"].oversize, input[type="password"].oversize, input[type="date"].oversize, input[type="datetime"].oversize, input[type="email"].oversize, input[type="number"].oversize, input[type="search"].oversize, input[type="tel"].oversize, input[type="time"].oversize, input[type="url"].oversize, textarea.oversize { 
-  font-size: 17px; 
-  padding: 4px 6px; 
+input[type="text"].oversize, input[type="password"].oversize, input[type="date"].oversize, input[type="datetime"].oversize, input[type="email"].oversize, input[type="number"].oversize, input[type="search"].oversize, input[type="tel"].oversize, input[type="time"].oversize, input[type="url"].oversize, textarea.oversize {
+  font-size: 17px;
+  padding: 4px 6px;
 }
-input[type="text"]:focus, input[type="password"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="email"]:focus, input[type="number"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="time"]:focus, input[type="url"]:focus, textarea:focus { 
-  outline: none !important; 
+input[type="text"]:focus, input[type="password"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="email"]:focus, input[type="number"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="time"]:focus, input[type="url"]:focus, textarea:focus {
+  outline: none !important;
   border-color: #ddc57e;
   -webkit-box-shadow: #ffe9a8 0 0 5px 0;
      -moz-box-shadow: #ffe9a8 0 0 5px 0;
        -o-box-shadow: #ffe9a8 0 0 5px 0;
-          box-shadow: #ffe9a8 0 0 5px 0; 
+          box-shadow: #ffe9a8 0 0 5px 0;
 }
 input[type="file"]:focus, input[type="file"]:active, input[type="radio"]:focus, input[type="radio"]:active, input[type="checkbox"]:focus, input[type="checkbox"]:active {
   -webkit-box-shadow: none;
@@ -3533,8 +3533,8 @@ input[type="file"]:focus, input[type="file"]:active, input[type="radio"]:focus, 
   -o-box-shadow: none;
   box-shadow: none;
 }
-input[type="text"][disabled], input[type="password"][disabled], input[type="date"][disabled], input[type="datetime"][disabled], input[type="email"][disabled], input[type="number"][disabled], input[type="search"][disabled], input[type="tel"][disabled], input[type="time"][disabled], input[type="url"][disabled], textarea[disabled] { 
-  background-color: #ddd; 
+input[type="text"][disabled], input[type="password"][disabled], input[type="date"][disabled], input[type="datetime"][disabled], input[type="email"][disabled], input[type="number"][disabled], input[type="search"][disabled], input[type="tel"][disabled], input[type="time"][disabled], input[type="url"][disabled], textarea[disabled] {
+  background-color: #ddd;
 }
 
 textarea { height: auto; }
@@ -3546,7 +3546,7 @@ textarea::-webkit-input-placeholder {
   color: #999999;
 }
 
-/* Fieldsets 
+/* Fieldsets
 fieldset { border: solid 1px #ddd; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; padding: 12px 12px 0; margin: 18px 0; }
 fieldset legend { font-weight: bold; background: white; padding: 0 3px; margin: 0 0 0 -3px; }*/
 
@@ -3624,7 +3624,7 @@ form.custom .custom.disabled { background-color: #ddd; }
         .searching .summary strong {
           font-weight: normal;
           font-family: PTSerifBold;
-          color: #444;      
+          color: #444;
         }
     .searching #loading_status { text-align: center; border: 1px solid #AAA; background-color: #EEE; }
     .searching  #show_more { text-align: center; border: 1px solid #CB4B16; background-color: #ffcebb; font-weight: bold; display: block; }
@@ -3648,7 +3648,7 @@ form.custom .custom.disabled { background-color: #ddd; }
 	  		border: none;
 	  		text-decoration: underline;
 	  	}
-	  
+
 
 /* Main Form styles =========================== */
 /* ============================================ */
@@ -3715,7 +3715,7 @@ form.custom .custom.disabled { background-color: #ddd; }
     /*overflow: hidden;*/
     /*width: 260px;*/
     }
-.advanced-search h3 {   
+.advanced-search h3 {
     text-align: center;
     text-transform: uppercase;
     margin: 0 0 8px;
@@ -3754,10 +3754,10 @@ select, input.text {
     font: 12px/16px CallunaSans, sans-serif;
     color: #444;
     border: solid #e6d39c 2px;
-    -moz-border-radius: 3px; 
-    -webkit-border-radius: 3px; 
+    -moz-border-radius: 3px;
+    -webkit-border-radius: 3px;
     border-radius: 3px;
-    -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box; 
+    -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box;
     }
 .advanced-search select {
     width: 120px;
@@ -3911,9 +3911,9 @@ select, input.text {
         padding: 2px;
     }
         #search-results .results-group h3,
-        #search-results .results-group h4 { 
-            text-align: left; 
-            width: auto; 
+        #search-results .results-group h4 {
+            text-align: left;
+            width: auto;
             font-size: 1em;
             margin-bottom: 1em;
             text-transform: uppercase;
@@ -4164,21 +4164,21 @@ input[type=text].default {
 	font-size: 90%;
 	color: #888;
 	}
-	
+
 #from_the_floor .date {
 	display: block;
 	margin-bottom: .5em;
 	}
-	
+
 .singlesignon li {
 	float: left;
 	margin-right: 5px;
 	}
-	
+
 small {
 	font-size: 80%;
 	}
-	
+
 ul.bullets, .postcontent ul {
 	list-style: circle;
 	margin-left: 1.75em;
@@ -4190,7 +4190,7 @@ ol.bullets, .postcontent ol {
 ul.bullets li, .postcontent ul li, ol.bullets li, .postcontent ol li {
 	margin: .25em 0 .25em 0;
 	}
-	
+
 .col_left {
 	width: 450px;
 	float: left;

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -856,8 +856,10 @@ img {
 @media only screen and (max-width: 767px) {
 
   body {
-    -webkit-text-size-adjust: none;
     -ms-text-size-adjust: none;
+    -webkit-text-size-adjust: none;
+    -moz-text-size-adjust: none;
+    text-size-adjust: none;
     width: 100%;
     min-width: 0;
     margin-left: 0;

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -405,13 +405,9 @@ sub {
   width: auto;
   background-size:1px 80px;
   background: #94bc6c; /* Old browsers */
-  background: -moz-linear-gradient(top,  #abd380 0%, #7fa659 100%); /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#abd380), color-stop(100%,#7fa659)); /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top,  #abd380 0%,#7fa659 100%); /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(top,  #abd380 0%,#7fa659 100%); /* Opera 11.10+ */
-  background: -ms-linear-gradient(top,  #abd380 0%,#7fa659 100%); /* IE10+ */
-  background: linear-gradient(to bottom,  #abd380 0%,#7fa659 100%); /* W3C */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#abd380', endColorstr='#7fa659',GradientType=0 ); /* IE6-9 */
+  background: -webkit-linear-gradient(top,  #abd380 0%,#7fa659 100%); /* Chrome10+,Safari5.1+ */
+  background: linear-gradient(to bottom,  #abd380 0%,#7fa659 100%); /* W3C */
   border-radius: 5px;
   border: 1px solid;
   border-color: #e3f1d5 #8eb566 #6f914d #8eb566;
@@ -3965,13 +3961,9 @@ ul.tabs a.active {
     color:#000;
     cursor:default;
     background: #f3f1e9; /* Old browsers */
-    background: -moz-linear-gradient(top,  #f3f1e9 1%, #ffffff 100%); /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(1%,#f3f1e9), color-stop(100%,#ffffff)); /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top,  #f3f1e9 1%,#ffffff 100%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top,  #f3f1e9 1%,#ffffff 100%); /* Opera 11.10+ */
-    background: -ms-linear-gradient(top,  #f3f1e9 1%,#ffffff 100%); /* IE10+ */
-    background: linear-gradient(to bottom,  #f3f1e9 1%,#ffffff 100%); /* W3C */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f3f1e9', endColorstr='#ffffff',GradientType=0 ); /* IE6-9 */
+    background: -webkit-linear-gradient(top,  #f3f1e9 1%,#ffffff 100%); /* Chrome10+,Safari5.1+ */
+    background: linear-gradient(to bottom,  #f3f1e9 1%,#ffffff 100%); /* W3C */
 }
 
 ul.tabs.two-up li a,
@@ -4056,13 +4048,9 @@ ul.left-tabs a.active {
     color:#000;
     cursor:default;
     background: #f0e9e0; /* Old browsers */
-    background: -moz-linear-gradient(top,  #edd 1%, #ffffff 100%); /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(1%,#edd), color-stop(100%,#ffffff)); /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top,  #edd 1%,#ffffff 100%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top,  #edd 1%,#ffffff 100%); /* Opera 11.10+ */
-    background: -ms-linear-gradient(top,  #edd 1%,#ffffff 100%); /* IE10+ */
-    background: linear-gradient(to bottom,  #edd 1%,#ffffff 100%); /* W3C */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#edd', endColorstr='#ffffff',GradientType=0 ); /* IE6-9 */
+    background: -webkit-linear-gradient(top,  #edd 1%,#ffffff 100%); /* Chrome10+,Safari5.1+ */
+    background: linear-gradient(to bottom,  #edd 1%,#ffffff 100%); /* W3C */
 }
 
 .left-tabs-panes {

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -221,12 +221,7 @@ pre {
     font-family: 'Droid Sans Mono', Monaco, "Courier New", Courier, monospace;
     border-left: 5px solid #eee;
     padding: 10px;
-
-    white-space: pre-wrap;       /* css-3 */
-    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-    white-space: -pre-wrap;      /* Opera 4-6 */
-    white-space: -o-pre-wrap;    /* Opera 7 */
-    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+    white-space: pre-wrap;
 }
 
 code {

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -293,12 +293,6 @@ sub {
 .topbox {
     background: #f3f1e9 url(../images/bg-paper.jpg);
     border: solid #e7e4dc 1px;
-    -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -411,12 +405,6 @@ sub {
   border-radius: 5px;
   border: 1px solid;
   border-color: #e3f1d5 #8eb566 #6f914d #8eb566;
-  -webkit-box-shadow:
-    0 0 0 1px rgb(130,169,91),
-    0 1px 0 rgba(255, 255, 255, 0.5) inset;
-  -moz-box-shadow:
-    0 0 0 1px rgb(130,169,91),
-    0 1px 0 rgba(255, 255, 255, 0.5) inset;
   box-shadow:
     0 0 0 1px rgb(130,169,91),
     0 1px 0 rgba(255, 255, 255, 0.5) inset;
@@ -450,13 +438,9 @@ sub {
   border-bottom: solid 1px #6f914d;
 }
 .button:active {
-  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2) inset;
-  -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2) inset;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2) inset;
 }
 .button:focus {
-  -webkit-box-shadow: 0 0 4px #cb4b16, 0 1px 0 rgba(255, 255, 255, 0.5) inset;
-  -moz-box-shadow: 0 0 4px #cb4b16, 0 1px 0 rgba(255, 255, 255, 0.5) inset;
   box-shadow: 0 0 4px #cb4b16, 0 1px 0 rgba(255, 255, 255, 0.5) inset;
   color: white;
 }
@@ -1544,9 +1528,6 @@ a.button.prefix, a.button.postfix {
           font-size: .85em;
           line-height: 1em;
           box-shadow: none;
-          -webkit-box-shadow: none;
-          -moz-box-shadow: none;
-          /*behavior: url(/static/js/PIE.htc);*/
         }*/
   #nav {
       height: 28px;
@@ -1621,11 +1602,8 @@ a.button.prefix, a.button.postfix {
       padding: 2px 8px 3px 9px;
       font-size: 12px;
       line-height: 28px;
-      -webkit-box-shadow: 0px 0px 4px #bcbbba;
-      -moz-box-shadow: 0px 0px 4px #bcbbba;
       box-shadow: 0px 0px 4px #bcbbba;
       display: none;
-      /*behavior: url(/static/js/PIE.htc);*/
   	}
       #nav ul ul li {
           float: none;
@@ -2124,12 +2102,6 @@ a.button.prefix, a.button.postfix {
     position: relative;
     background: #f3f1e9 url(../images/bg-paper.jpg);
     border: solid #e7e4dc 1px;
-    -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -2270,12 +2242,6 @@ a.button.prefix, a.button.postfix {
     position: relative;
     background: #f3f1e9 url(../images/bg-paper.jpg);
     border: solid #e7e4dc 1px;
-    -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -2752,18 +2718,11 @@ aside .download-links { padding: 31px 0 0 	}
     position: relative;
     background-color: #fcfcfc;
     border: solid #e7e4dc 1px;
-    -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
     padding: 10px;
     cursor: pointer;
-    /*behavior: url(/static/js/PIE.htc);*/
 }
 .lt-ie9 #lists div.list {
   box-shadow: none;
@@ -2783,12 +2742,6 @@ aside .download-links { padding: 31px 0 0 	}
 #lists div.active {
     color: black;
     background-color: #fffbf0;
-    -moz-box-shadow:
-        0 0 0 5px #fcf3d0,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #fcf3d0,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #fcf3d0,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -2887,12 +2840,6 @@ aside .download-links { padding: 31px 0 0 	}
     .side-box {
       background: #f8f7f7;
       border: solid #e7e4dc 1px;
-      -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-      -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
       box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -3054,11 +3001,8 @@ aside .download-links { padding: 31px 0 0 	}
 }
 #list_trackers li:hover,
 #basic_trackers li a:hover {
-    -webkit-box-shadow:
-        0 2px 5px rgba(0,0,0,.2);
     box-shadow:
         0 2px 5px rgba(0,0,0,.2);
-    /*behavior: url(/static/js/PIE.htc);*/
 }
     #list_trackers li span {
         display: inline-block;
@@ -3131,16 +3075,12 @@ aside .download-links { padding: 31px 0 0 	}
         /*background: #f8f7f7;
         border-radius: 1px;
         border: solid #e7e4dc 1px;
-        -webkit-box-shadow:
-            0 0 0 5px #f9f8f4,
-            0 3px 8px 5px rgba(106,106,106,.4);
         box-shadow:
             0 0 0 5px #f9f8f4,
             0 3px 8px 5px rgba(106,106,106,.4);*/
         padding-top: 18px;
         background: url(../images/tracker_widget_top.png) center 0 no-repeat;
         font-family: 'CallunaSans';
-        /*behavior: url(/static/js/PIE.htc);*/
     }
         .widget_content {
             position: relative;
@@ -3201,17 +3141,12 @@ aside .download-links { padding: 31px 0 0 	}
                 color: #fff;
             }
             .list_select li a:hover {
-                -webkit-box-shadow:
-                    0 2px 5px rgba(0,0,0,.2);
                 box-shadow:
                     0 2px 5px rgba(0,0,0,.2);
-                /*behavior: url(/static/js/PIE.htc);*/
             }
             .list_select li.new a:hover,
             .list_select li.all a:hover {
-                -webkit-box-shadow: none;
                 box-shadow: none;
-                /*behavior: url(/static/js/PIE.htc);*/
             }
                 .events_to_track li span.icon,
                 .list_select li span.icon    {
@@ -3466,8 +3401,6 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
   border-color: #e6d39c ;
   outline: 0;
   background: #ffffff url('../images/input_field.png') left top repeat-x;
-  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   color: #555;
   display: block;
@@ -3484,15 +3417,9 @@ input[type="text"].oversize, input[type="password"].oversize, input[type="date"]
 input[type="text"]:focus, input[type="password"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="email"]:focus, input[type="number"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="time"]:focus, input[type="url"]:focus, textarea:focus {
   outline: none !important;
   border-color: #ddc57e;
-  -webkit-box-shadow: #ffe9a8 0 0 5px 0;
-     -moz-box-shadow: #ffe9a8 0 0 5px 0;
-       -o-box-shadow: #ffe9a8 0 0 5px 0;
-          box-shadow: #ffe9a8 0 0 5px 0;
+  box-shadow: #ffe9a8 0 0 5px 0;
 }
 input[type="file"]:focus, input[type="file"]:active, input[type="radio"]:focus, input[type="radio"]:active, input[type="checkbox"]:focus, input[type="checkbox"]:active {
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
-  -o-box-shadow: none;
   box-shadow: none;
 }
 input[type="text"][disabled], input[type="password"][disabled], input[type="date"][disabled], input[type="datetime"][disabled], input[type="email"][disabled], input[type="number"][disabled], input[type="search"][disabled], input[type="tel"][disabled], input[type="time"][disabled], input[type="url"][disabled], textarea[disabled] {
@@ -3652,12 +3579,6 @@ form.custom .custom.disabled { background-color: #ddd; }
     background: #f3f1e9 url(../images/bg-paper.jpg);
     margin: 4px 0 30px;
     border: solid #e7e4dc 1px;
-    -moz-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
-    -webkit-box-shadow:
-        0 0 0 5px #f9f8f4,
-        0 1px 2px 5px rgba(106,106,106,.4);
     box-shadow:
         0 0 0 5px #f9f8f4,
         0 1px 2px 5px rgba(106,106,106,.4);
@@ -3821,9 +3742,6 @@ select, input.text {
         background: #f8f7f7;
         border-radius: 1px;
         border: solid #e7e4dc 1px;
-        -webkit-box-shadow:
-            0 0 0 5px #f9f8f4,
-            0 1px 2px 5px rgba(106,106,106,.4);
         box-shadow:
             0 0 0 5px #f9f8f4,
             0 1px 2px 5px rgba(106,106,106,.4);
@@ -4182,9 +4100,7 @@ ul.bullets li, .postcontent ul li, ol.bullets li, .postcontent ol li {
 	z-index: 999;
     border-top: 2px solid #fff6d3;
     border-bottom: 2px solid #f6db71;
-    -webkit-box-shadow: 0px 2px 4px 0px #666;
-            box-shadow: 0px 2px 4px 0px #666;
-    /*behavior: url(/static/js/PIE.htc);*/
+    box-shadow: 0px 2px 4px 0px #666;
 }
 #sitenews {
 	margin: 0 auto;


### PR DESCRIPTION
This addresses the following properties:
- border-radius
- border-top-right-radius
- border-bottom-right-radius
- border-top-left-radius
- border-bottom-left-radius
- linear-gradient
- box-shadow
- white-space: pre-wrap
- background-clip

It also adds more support for the 'text-size-adjust' property which affects mobile users, and which seemed to have lopsided support.

Beware: This converts the file to use Unix-style line endings (\n), which is in direct contradiction to the changes made in #46. (The file was mostly Windows-style line endings (\r\n), so that other pull request sought to normalize them with the least amount of churn. This pull request, on the other hand, directly addresses the CSS file and seeks to normalize to the standard used everywhere else.)
