### PR TITLE
Make site-wide link style only apply to actual links.

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -133,16 +133,17 @@ body {
 	-webkit-font-smoothing: antialiased;
 	position: relative;
 	}
-a {
+a:link, a:visited {
 	color: #cb4b16;
 	}
-a:hover {
+a:hover, a:focus, a:active {
 	color: #664030;
 	}
-a.plain, #masthead a {
+a.plain:link, #masthead a:link {
 	text-decoration: none;
 	}
-a.plain:hover, #masthead a:hover {
+a.plain:hover, a.plain:focus, a.plain:active,
+#masthead a:hover, #masthead a:focus, #masthead a:active {
 	text-decoration: underline;
 	}
 input, textarea, select {


### PR DESCRIPTION
This should fix the issue with href-less links, so you can turn the cross-referencing back on.

Also note that I pushed a few no-op CSS changes to master earlier in order to unify the whitespace in the CSS file.

Let me know if you see any fallout from any of this. (Note that I still support the merger of #47 for #1, though I haven't taken a direct look at it lately.)
