### PR TITLE
Pin django-html-emailer

### DIFF
--- a/build/pipreq.txt
+++ b/build/pipreq.txt
@@ -22,7 +22,7 @@ pyyaml
 pynliner
 git+https://github.com/govtrack/django-lorien-common
 phonenumbers
-git+https://github.com/if-then-fund/django-html-emailer
+git+https://github.com/if-then-fund/django-html-emailer@v0.0.2
 xml_diff
 diff_match_patch_python
 python-twitter


### PR DESCRIPTION
Newer versions are not compatible with Django 1.7.