### PR TITLE
Install django-extensions

### DIFF
--- a/build/pipreq.txt
+++ b/build/pipreq.txt
@@ -3,6 +3,7 @@ uwsgi
 python-dateutil
 django-cache-utils
 django-debug-toolbar
+django-extensions
 django-picklefield
 mimeparse
 defusedxml

--- a/settings.py
+++ b/settings.py
@@ -119,6 +119,7 @@ INSTALLED_APPS = (
     'django_wysiwyg',
     'django_twilio',
     'htmlemailer',
+    'django_extensions',
     
     # project modules
     'twostream',


### PR DESCRIPTION
The package `django-extensions` needs to be installed and registered as an installed app before running the `generate_secret_key` command.