### PR TITLE
Pin version of twilio

### DIFF
--- a/build/pipreq.txt
+++ b/build/pipreq.txt
@@ -18,7 +18,7 @@ rcssmin
 paypalrestsdk
 markdown2
 django_twilio
-twilio
+twilio==4.4.0
 tqdm
 pyyaml
 pynliner


### PR DESCRIPTION
A recent version of the twilio package (version 6) introduced breaking changes. The twilio.twiml module has changed, so that `from twilio.twiml import Response as TwilioResponse` now throws an exception when rendering the homepage. Pinning this version will fix new installs.