### PR TITLE
Fixed Name Plate Issue on Representative List

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -234,7 +234,7 @@ blockquote {
 	text-indent: -9999px;
 	overflow: hidden;
 }
-	
+
 .breadcrumb {
 	margin-top: 15px;
 	margin-bottom: 0;
@@ -1048,14 +1048,14 @@ ul.singlesignon {
 	padding: 3px 3px 1px 5px;
 	position:relative;
 	line-height: 128%;
-    min-height: 20px;
+  min-height: 20px;
 	top: -4px;
 	left:-10px;
 	margin: 0 auto;
 	font-weight: bold;
 }
 	@media screen and (min-width: 768px) {
-		.photo_flag {
+		.photo_flag.committee {
 			left: -6px;
 		}
 	}
@@ -1140,7 +1140,7 @@ ul.singlesignon {
 	left:0px;
 	top:0px;
 	background:#BF1722;
-	outline:0;	
+	outline:0;
 	-webkit-transition: top .1s ease-in, background .5s linear;
     transition: top .1s ease-in, background .5s linear;
 }

--- a/templates/committee/committee_details.html
+++ b/templates/committee/committee_details.html
@@ -63,7 +63,7 @@
 				{% endfor %}
 			</dl>
 
-			
+
 			{% if member_highlights|length > 0 %}
 			<p style="line-height: 110%"><small>The chair is always selected from the majority party and the ranking member is the most senior member of the minority party.</small></p>
 			{% endif %}
@@ -71,14 +71,14 @@
 			<p style="line-height: 110%"><small>The majority party ensures it has a majority on every committee.</small></p>
 			{% endif %}
 			</small></p>
-			
+
 			{% if members|length == 0 %}
 			<p>The membership of this committee is not yet available.</p>
 			{% endif %}
 
 	</div>
-	
-	
+
+
 
 	<div class="aside col-sm-4">
 		<a href="#" class="track-btn" onclick="return show_track_panel();">Track Committee</a>
@@ -111,20 +111,20 @@
 		        {% if forloop.counter0|divisibleby:4 %}<div class="clearfix visible-sm"></div>{% endif %}
 		        {% if forloop.counter0|divisibleby:2 %}<div class="clearfix visible-xs"></div>{% endif %}
 		        <div class="member col-xs-6 col-sm-3 col-md-2">
-	            	
+
 		            <div class="photo">
 	            		<a href="{{ member.person.get_absolute_url }}"><img src="{{ member.person.get_photo_url_100 }}" width="100" height="120" alt="Portrait of {{ member.person.name_no_details }}"/></a>
 	            	</div>
-	            	
+
 		            {% with member.person.get_current_role as role %}
-		            
+
 					{% if member.role != SIMPLE_MEMBER %}
-		            <div class="photo_flag flag_{{role.party|slice:":1"|lower}}">
+		            <div class="photo_flag flag_{{role.party|slice:":1"|lower}} committee">
 		            	{{ member.get_role_display }}
 		            </div>
 		            {% else %}
 	            	{% if member.subcommittee_role %}
-	                <div class="photo_flag flag_{{role.party|slice:":1"|lower}} sub_chair" title="Subcommittee {{member.subcommittee_role.role_name}}: {{member.subcommittee_role.committee.name}}">
+	                <div class="photo_flag flag_{{role.party|slice:":1"|lower committee}} sub_chair" title="Subcommittee {{member.subcommittee_role.role_name}}: {{member.subcommittee_role.committee.name}}">
 	                	{{member.subcommittee_role.committee.name|cut:"The "|truncatewords:1}}
 	                </div>
 	            	{% endif %}
@@ -142,7 +142,7 @@
 		            	<div>{{role.state}}-{{role.district}}</div>
 		            	{% endif %}
 		            	<div>{{role.party}}</div>
-		            	
+
 						{% if member.subcommittee_role %}
 							<div style="font-size: 95%; line-height: 120%; border-top: 1px solid #AAA; margin-top: 3px; padding-top: 3px;">{{member.subcommittee_role.role_name}}, Subcommittee on <a href="{{member.subcommittee_role.committee.url}}" class="plain">{{member.subcommittee_role.committee.name|truncatewords:7}}</a></div>
 						{% endif %}
@@ -153,7 +153,7 @@
 		    </div>
 		</div>
 		{% endif %}
-		
+
 		<div id="activity" class="tab-pane {% if members|length == 0 %}active{% endif %}">
 				<h2>Bills</h2>
 				{% if committee.has_current_bills %}
@@ -188,7 +188,7 @@
 			</tbody>
 			</table>
 		</div>
-		
+
 		{% if subcommittees %}
 		<div id="subcommittees" class="tab-pane">
 			<h2>Subcommittees</h2>


### PR DESCRIPTION
Hello, I saw there was an issue on the site when you list Representatives by their state on Desktop. The subtext under the picture looks nice when listen by committee, so I just added another CSS class when listing Representatives by a committee. (Also, deleted some empty lines) Please let me know if you need anything else!

Example:

List by Committee:
![screen shot 2017-09-06 at 1 05 22 am](https://user-images.githubusercontent.com/6139501/30101037-b3a20cb4-929f-11e7-9119-e837b2453807.png)

Previous List by State:
![screen shot 2017-09-06 at 1 05 48 am](https://user-images.githubusercontent.com/6139501/30101054-c6f5d804-929f-11e7-8b47-22a2f924636a.png)

Fixed List by State:
![screen shot 2017-09-06 at 1 08 36 am](https://user-images.githubusercontent.com/6139501/30101103-f37804f6-929f-11e7-82ac-400b975f6057.png)
