### PR TITLE
Make "relevance" the default search when searching for text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ data
 
 .idea
 django-fixture*
+*.swp

--- a/bill/views.py
+++ b/bill/views.py
@@ -461,8 +461,8 @@ def show_bill_browse(template, request, ix1, ix2, context):
         # pass through
         default_sort = request.GET["sort"]
     elif "text" in request.GET:
-        # when the user is doing a text search, sort by standard Solr relevance scoring, which includes boosting the bill title
-        default_sort = None
+        # when the user is doing a text search, sort by relevance to that text
+        default_sort = "relevance"
     elif "sponsor" in request.GET:
         # when searching by sponsor, the default order is to show bills in reverse chronological order
         default_sort = "-introduced_date"

--- a/smartsearch/templates/smartsearch/search_panel.html
+++ b/smartsearch/templates/smartsearch/search_panel.html
@@ -232,11 +232,16 @@ function update_search(pagenum, pageinc, elem, isinitial) {
     if (isinitial) {
         // The initial search combines the default faceting with the URL fragment.
         var fragment_params = parse_qs.fragment();
+
         for (var k in default_search) postdata[k] = default_search[k];
         for (var k in fragment_params) postdata[k] = fragment_params[k];
         for (var k in fragment_params)
             if (fragment_params[k] == "__ALL__")
                 delete postdata[k]; // null is not sufficient
+
+	// Make sure a text search behaves predictably
+	if ("text" in fragment_params)
+	    postdata["sort"]="relevance";
 
         // Update the sort control.
         if ("sort" in postdata)


### PR DESCRIPTION
This replaces the previous bahavior which relied on Solr "boosting"
text-relevant matches, after noticing that Solr sometimes badly fails
to uprank highly-relevant text matches.

The example is a search for "john mccain national defense authorization"
which failed to put the bills with the corresponding titles in the first
several dozen results. The new default of sorting text ordered by relevance
fixes this unintuitive behavior.