### PR TITLE
Always show position statement section

### DIFF
--- a/templates/bill/bill_details.html
+++ b/templates/bill/bill_details.html
@@ -601,7 +601,6 @@
 
 	<div id="admin_panel"> </div>
 
-{% if stakeholder_posts or legislator_statements %}
 <div style="margin: 30px 0;">
   <h2 style="margin-bottom: 15px;"><span>Position statements</span></h2>
 
@@ -674,7 +673,6 @@
 	</a>
   </div>
 </div>
-{% endif %}
 
 	{% if text_incorporation and bill.is_success %}
 		<h2><span>Incorporated legislation</span></h2>


### PR DESCRIPTION
If the section is empty, no MoC press releases or stakeholder statements, it only shows the link to register as a stakeholder.