### PR TITLE
Fixed typo: "Miseed" to "Missed"

### DIFF
--- a/templates/vote/presidential_candidates.html
+++ b/templates/vote/presidential_candidates.html
@@ -121,7 +121,7 @@ function build_chart(data) {
         yAxis: [{ min: 0, max: 100, title: { text: 'Missed Votes (%)' } }],
         tooltip: {
             formatter: function() {
-                return this.series.options.election_year + " Election<br>" + this.series.options.legislator_name + "<br/>Miseed " + this.y  + "% of Votes" + "<br/>" + x_axis_index_to_days(this.x) + " days before the " + this.series.options.election_year + " election";
+                return this.series.options.election_year + " Election<br>" + this.series.options.legislator_name + "<br/>Missed " + this.y  + "% of Votes" + "<br/>" + x_axis_index_to_days(this.x) + " days before the " + this.series.options.election_year + " election";
             }
         },
         plotOptions: {


### PR DESCRIPTION
Typo appears in the graph at the top of https://www.govtrack.us/congress/votes/presidential-candidates:
![crop](https://user-images.githubusercontent.com/2555049/71591954-4b334d80-2afc-11ea-9293-820334c65c70.png)
