### PR TITLE
added Kahele & Rush

### DIFF
--- a/templates/website/covid19.html
+++ b/templates/website/covid19.html
@@ -624,6 +624,11 @@ $(function() {
 		<tr class="tested-positive" data-expected-end-date="01/05/2022"><td>12/22/21</td> <td><a href="https://www.govtrack.us/congress/members/janice_schakowsky/400360" class="legislator">Rep. Jan Schakowsky (IL-9)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/5/22</td> <td><a href="https://twitter.com/janschakowsky/status/1473850745107718148?s=20">tweet</a></td>
 
 		<tr class="tested-positive" data-expected-end-date="01/05/2022"><td>12/22/21</td> <td><a href="https://www.govtrack.us/congress/members/christopher_coons/412390" class="legislator">Sen. Chris Coons (DE)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/5/22</td> <td><a href="https://twitter.com/ChrisCoons/status/1474048617547804678?s=20">tweet</a></td>
+
+		<tr class="tested-positive" data-expected-end-date="01/05/2022"><td>12/26/21</td> <td><a href="https://www.govtrack.us/congress/members/kaialii_kahele/456815" class="legislator">Rep. Kaialiʻi Kahele (HI-2)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/5/22</td> <td><a href="https://twitter.com/RepKahele/status/1475199120805556225?s=20">tweet</a></td>
+		
+		<tr class="tested-positive" data-expected-end-date="01/06/2022"><td>12/27/21</td> <td><a href="https://www.govtrack.us/congress/members/bobby_rush/400350" class="legislator">Rep. Bobby Rush (IL-1)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/6/22</td> <td><a href="https://twitter.com/RepBobbyRush/status/1475690139091361792?s=20">tweet</a></td>
+
 </tbody>
 	</table>
 


### PR DESCRIPTION
shorted expected end date based on new CDC guidelines, but kept both Kahele & Rush at 10 days bc the new guidelines say you can only leave isolation if you're asymptomatic _at_ 5 days & Rush could develop symptoms between now & then. Happy to change though if you want me to drop Rush to 5 days expected end date (which would be this Sat, 1/1/22)