### PR TITLE
covid19: added schatz, hoyer, hoeven, schneider, jacobs

### DIFF
--- a/templates/website/covid19.html
+++ b/templates/website/covid19.html
@@ -665,6 +665,8 @@ $(function() {
 
 		<tr class="tested-positive" data-expected-end-date="01/17/2022"><td>1/12/22</td> <td><a href="https://www.govtrack.us/congress/members/gary_palmer/412608" class="legislator">Rep. Gary Palmer (AL-6)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/17/22</td> <td><a href="https://twitter.com/CraigCaplan/status/1484171966554820609?s=20">tweet</a></td></tr>
 
+		<tr class="tested-positive" data-expected-end-date="01/18/2022"><td>1/13/22</td> <td><a href="https://www.govtrack.us/congress/members/brian_schatz/412507" class="legislator">Sen. Brian Schatz (HI)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/18/22</td> <td><a href="https://www.schatz.senate.gov/news/press-releases/statement-from-senator-schatz">press release</a></td></tr>
+
 		<tr class="tested-positive" data-expected-end-date="01/19/2022"><td>1/14/22</td> <td><a href="https://www.govtrack.us/congress/members/ashley_hinson/456816" class="legislator">Rep. Ashley Hinson (IA-1)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/19/22</td> <td><a href="https://twitter.com/RepAshleyHinson/status/1481988353067294721?s=20">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date="01/22/2022"><td>1/17/22</td> <td><a href="https://www.govtrack.us/congress/members/diana_degette/400101" class="legislator">Rep. Diana DeGette (CO-1)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/21/22</td> <td><a href="https://twitter.com/RepDianaDeGette/status/1483116031598075905?s=20">tweet</a></td></tr>
@@ -683,13 +685,19 @@ $(function() {
 
 		<tr class="tested-positive" data-expected-end-date="01/25/2022"><td>1/20/22</td> <td><a href="https://www.govtrack.us/congress/members/thomas_massie/412503" class="legislator">Rep. Thomas Massie (KY-4)</a></td> <td><b>tested positive</b> again after having it sometime before August 2020</td> <td>isolation until 1/25/22</td> <td><a href="https://twitter.com/RepThomasMassie/status/1484159395802058755?s=20">tweet</a></td></tr>
 
-		<tr class="tested-positive" data-expected-end-date="02/02/2022"><td>1/28/22</td> <td><a href="https://www.govtrack.us/congress/members/mitt_romney/412841" class="legislator">Sen. Mitt Romney (UT)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/2/22</td> <td><a href="https://www.romney.senate.gov/statement-from-senator-romneys-office/">press release</a></td></tr>
-
 		<tr class="tested-positive" data-expected-end-date="01/30/2022"><td>1/25/22</td> <td><a href="https://www.govtrack.us/congress/members/mark_warner/412321" class="legislator">Sen. Mark Warner (VA)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/30/22</td> <td><a href="https://twitter.com/MarkWarner/status/1486126661926101005?s=20">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date=01/30/2022"><td>1/25/22</td> <td><a href="https://www.govtrack.us/congress/members/melanie_stansbury/456861" class="legislator">Rep. Melanie Stansbury (NM-1)</a></td> <td><b>tested positive</b></td> <td>isolation until 1/30/22</td> <td><a href="https://twitter.com/Rep_Stansbury/status/1486172508227309570?s=20">tweet</a></td></tr>
 
-<tr class="tested-positive" data-expected-end-date="02/04/2022"><td>1/30/22</td> <td><a href="https://www.govtrack.us/congress/members/colin_allred/412828" class="legislator">Rep. Colin Allred (TX-32)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/4/22</td> <td><a href="https://twitter.com/RepColinAllred/status/1487905247402106890?s=20&t=lqBfgu_UgmbG4oni_W330Q">tweet</a></td></tr>
+		<tr class="tested-positive" data-expected-end-date="02/02/2022"><td>1/28/22</td> <td><a href="https://www.govtrack.us/congress/members/mitt_romney/412841" class="legislator">Sen. Mitt Romney (UT)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/2/22</td> <td><a href="https://www.romney.senate.gov/statement-from-senator-romneys-office/">press release</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="02/04/2022"><td>1/30/22</td> <td><a href="https://www.govtrack.us/congress/members/colin_allred/412828" class="legislator">Rep. Colin Allred (TX-32)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/4/22</td> <td><a href="https://twitter.com/RepColinAllred/status/1487905247402106890?s=20&t=lqBfgu_UgmbG4oni_W330Q">tweet</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="02/06/2022"><td>2/1/22</td> <td><a href="https://www.govtrack.us/congress/members/steny_hoyer/400189" class="legislator">Rep. Steny Hoyer (MD-5)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/6/22</td> <td><a href="https://twitter.com/LeaderHoyer/status/1488649291115552770?s=20&t=mA_LdqO8MEDeBrxQf7xWKw">tweet</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="02/06/2022"><td>2/1/22</td> <td><a href="https://www.govtrack.us/congress/members/john_hoeven/412494" class="legislator">Sen. John Hoeven (ND)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/6/22</td> <td><a href="https://twitter.com/SenJohnHoeven/status/1488634927205818375?s=20&t=V7AGI1ikQqi36AjZaujLnw">tweet</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="02/06/2022"><td>2/1/22</td> <td><a href="https://www.govtrack.us/congress/members/bradley_schneider/412534" class="legislator">Rep. Brad Schneider (IL-10)</a></td> <td><b>tested positive</b> for a second time</td> <td>isolation until 2/6/22</td> <td><a href="https://twitter.com/RepSchneider/status/1488692894366146562?s=20&t=Qwy7-gMJghAodHzzfCfySg">tweet</a></td></tr>
 
 </tbody>
   </table>

--- a/templates/website/covid19.html
+++ b/templates/website/covid19.html
@@ -699,6 +699,8 @@ $(function() {
 
 		<tr class="tested-positive" data-expected-end-date="02/06/2022"><td>2/1/22</td> <td><a href="https://www.govtrack.us/congress/members/bradley_schneider/412534" class="legislator">Rep. Brad Schneider (IL-10)</a></td> <td><b>tested positive</b> for a second time</td> <td>isolation until 2/6/22</td> <td><a href="https://twitter.com/RepSchneider/status/1488692894366146562?s=20&t=Qwy7-gMJghAodHzzfCfySg">tweet</a></td></tr>
 
+		<tr class="tested-positive" data-expected-end-date="02/07/2022"><td>2/2/22</td> <td><a href="https://www.govtrack.us/congress/members/sara_jacobs/456804" class="legislator">Rep. Sara Jacobs (CA-53)</a></td> <td><b>tested positive</b></td> <td>isolation until 2/7/22</td> <td><a href="https://twitter.com/RepSaraJacobs/status/1488959541098209282?s=20&t=07WrX5uCNTsGLx6RGrVJvg">tweet</a></td></tr>
+
 </tbody>
   </table>
 


### PR DESCRIPTION
moved Romney to the right location