### PR TITLE
covid19: many updates

### DIFF
--- a/templates/website/covid19.html
+++ b/templates/website/covid19.html
@@ -805,6 +805,8 @@ $(function() {
 		
 		<tr class="tested-positive" data-expected-end-date="05/03/2022"><td>4/28/22</td> <td><a href="https://www.govtrack.us/congress/members/rick_allen/412625" class="legislator">Rick Allen (GA-12)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/3/22</td> <td><a href="https://twitter.com/RepRickAllen/status/1519698205834944514">tweet</a></td></tr>
 
+		<tr class="tested-positive" data-expected-end-date="05/06/2022"><td>5/1/22</td> <td><a href="https://www.govtrack.us/congress/members/michael_bennet/412330" class="legislator">Sen. Michael Bennet (CO)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/6/22</td> <td><a href="https://www.bennet.senate.gov/public/index.cfm/2022/5/bennet-statement-on-positive-covid-19-test-result">press release</a></td></tr>
+
 </tbody>
   </table>
 

--- a/templates/website/covid19.html
+++ b/templates/website/covid19.html
@@ -740,6 +740,8 @@ $(function() {
 		<tr class="tested-positive" data-expected-end-date="03/20/2022"><td>3/15/22</td> <td><a href="https://www.govtrack.us/congress/members/jared_golden/412842" class="legislator">Rep. Jared Golden (ME-2)</a></td> <td><b>tested positive</b></td> <td>isolation until 3/20/22</td> <td><a href="https://twitter.com/RepGolden/status/1503749134913884171">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date="03/20/2022"><td>3/15/22</td> <td><a href="https://www.govtrack.us/congress/members/fred_upton/400414" class="legislator">Rep. Fred Upton (MI-6)</a></td> <td><b>tested positive</b></td> <td>isolation until 3/20/22</td> <td><a href="https://twitter.com/RepFredUpton/status/1503821997066928132">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="03/24/2022"><td>3/19/22</td> <td><a href="https://www.govtrack.us/congress/members/tom_ohalleran/412682" class="legislator">Rep. Tom O'Halleran (AZ-1)</a></td> <td><b>tested positive</b></td> <td>isolation until 3/24/22</td> <td><a href="https://twitter.com/RepOHalleran/status/1505306252708044806">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date="03/27/2022"><td>3/22/22</td> <td><a href="https://www.govtrack.us/congress/members/robert_casey/412246" class="legislator">Sen. Bob Casey (PA)</a></td> <td><b>tested positive</b></td> <td>isolation until 3/27/22</td> <td><a href="https://mobile.twitter.com/SenBobCasey/status/1506389996361719812">tweet</a></td></tr>
 
@@ -769,6 +771,18 @@ $(function() {
 
 		<tr class="tested-positive" data-expected-end-date="04/13/2022"><td>4/8/22</td> <td><a href="https://www.govtrack.us/congress/members/raja_krishnamoorthi/412701" class="legislator">Rep. Raja Krishnamoorthi (IL-8)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/13/22</td> <td><a href="https://twitter.com/CongressmanRaja/status/1512388923238014977">tweet</a></td></tr>
 
+		<tr class="tested-positive" data-expected-end-date="04/13/2022"><td>4/8/22</td> <td><a href="https://www.govtrack.us/congress/members/sheila_cherfilus_mccormick/456865" class="legislator">Rep. Sheila Cherfilus-McCormick (FL-20)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/13/22</td> <td><a href="https://cherfilus-mccormick.house.gov/media/press-releases/congresswoman-cherfilus-mccormick-spokesman-statement-congresswomans-positive">press release</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="04/13/2022"><td>4/8/22</td> <td><a href="https://www.govtrack.us/congress/members/lisa_blunt_rochester/412689" class="legislator">Rep. Lisa Blunt Rochester (DE-0)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/13/22</td> <td><a href="https://twitter.com/RepLBR/status/1512457233786880007">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="04/13/2022"><td>4/8/22</td> <td><a href="https://www.govtrack.us/congress/members/frank_pallone/400308" class="legislator">Rep. Frank Pallone (NJ-6)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/13/22</td> <td><a href="https://twitter.com/FrankPallone/status/1512586711972392961">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="04/15/2022"><td>4/10/22</td> <td><a href="https://www.govtrack.us/congress/members/jackie_speier/412259" class="legislator">Rep. Jackie Speier (CA-14)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/15/22</td> <td><a href="https://twitter.com/RepSpeier/status/1513263070667501570">tweet</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="04/15/2022"><td>4/10/22</td> <td><a href="https://www.govtrack.us/congress/members/elaine_luria/412830" class="legislator">Rep. Elaine Luria (VA-2)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/15/22</td> <td><a href="https://www.wavy.com/news/local-news/virginia-beach/rep-elaine-luria-tests-positive-for-covid-19/">news</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="04/16/2022"><td>4/11/22</td> <td><a href="https://www.govtrack.us/congress/members/earl_blumenauer/400033" class="legislator">Rep. Earl Blumenauer (OR-3)</a></td> <td><b>tested positive</b></td> <td>isolation until </td> <td><a href="https://blumenauer.house.gov/media-center/press-releases/congressman-blumenauer-tests-positive-covid">press release</a></td></tr>
+
 		<tr class="tested-positive" data-expected-end-date="04/16/2022"><td>4/11/22</td> <td><a href="https://www.govtrack.us/congress/members/rashida_tlaib/412787" class="legislator">Rep. Rashida Tlaib (MI-13)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/16/22</td> <td><a href="https://twitter.com/RashidaTlaib/status/1513547143893684236">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date="04/18/22"><td>4/13/22</td> <td><a href="https://www.govtrack.us/congress/members/gwen_moore/400661" class="legislator">Rep. Gwen Moore (WI-4)</a></td> <td><b>tested positive</b> for a 2nd time; first was late Dec. 2020</td> <td>isolation until 4/18/22</td> <td><a href="https://twitter.com/RepGwenMoore/status/1514433540297007110">tweet</a></td></tr>
@@ -776,6 +790,20 @@ $(function() {
 		<tr class="tested-positive" data-expected-end-date="04/24/2022"><td>4/19/22</td> <td><a href="https://www.govtrack.us/congress/members/carolyn_maloney/400251" class="legislator">Rep. Carolyn Maloney (NY-12)</a></td> <td><b>tested positive</b></td> <td>isolation until 04/24/22</td> <td><a href="https://twitter.com/CarolynBMaloney/status/1516452817732571136">tweet</a></td></tr>
 
 		<tr class="tested-positive" data-expected-end-date="04/26/2022"><td>4/21/22</td> <td><a href="https://www.govtrack.us/congress/members/andy_levin/412785" class="legislator">Rep. Andy Levin (MI-9)</a></td> <td><b>tested positive</b></td> <td>isolation until 4/26/22</td> <td><a href="https://twitter.com/RepAndyLevin/status/1517237944989409284">tweet</a></td></tr>
+
+		<tr class="tested-positive" data-expected-end-date="04/30/2022"><td>4/25/22</td> <td><a href="https://www.govtrack.us/congress/members/joseph_morelle/412749" class="legislator">Rep. Joseph Morelle (NY-25)</a></td> <td><b>tested positive</b></td> <td>isolation until </td> <td><a href="https://twitter.com/RepJoeMorelle/status/1518666974687072256">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/01/2022"><td>4/26/22</td> <td><a href="https://www.govtrack.us/congress/members/deborah_ross/456831" class="legislator">Rep. Deborah Ross (NC-2)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/1/22</td> <td><a href="https://twitter.com/RepDeborahRoss/status/1519040060611563521">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/01/2022"><td>4/26/22</td> <td><a href="https://www.govtrack.us/congress/members/christopher_murphy/412194" class="legislator">Sen. Chris Murphy (CT)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/1/22</td> <td><a href="https://twitter.com/ChrisMurphyCT/status/1518981877209706499">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/01/2022"><td>4/26/22</td> <td><a href="https://www.govtrack.us/congress/members/ron_wyden/300100" class="legislator">Sen. Ron Wyden (OR)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/1/22</td> <td><a href="https://twitter.com/RonWyden/status/1518986999251849218">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/02/2022"><td>4/27/22</td> <td><a href="https://www.govtrack.us/congress/members/maxine_waters/400422" class="legislator">Rep. Maxine Waters (CA-43)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/2/22</td> <td><a href="https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=409352">press release</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/02/2022"><td>4/27/22</td> <td><a href="https://www.govtrack.us/congress/members/ed_perlmutter/412192" class="legislator">Rep. Ed Perlmutter (CO-7)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/2/22</td> <td><a href="https://twitter.com/RepPerlmutter/status/1519421057949708297">tweet</a></td></tr>
+		
+		<tr class="tested-positive" data-expected-end-date="05/03/2022"><td>4/28/22</td> <td><a href="https://www.govtrack.us/congress/members/rick_allen/412625" class="legislator">Rick Allen (GA-12)</a></td> <td><b>tested positive</b></td> <td>isolation until 5/3/22</td> <td><a href="https://twitter.com/RepRickAllen/status/1519698205834944514">tweet</a></td></tr>
 
 </tbody>
   </table>


### PR DESCRIPTION
some we missed earlier that PBS had in their list (I think legislators tried to keep quiet in some cases); a new batch this week as well. Anyway: added o'halleran, cherfilus-mccormick, rochester, pallone, speier, luria, bluemenauer, morelle, ross, murphy, wyden, waters, perlmutter, allen. I have no sense of whether there will be more today or not.